### PR TITLE
C++11 flag added and pystr_startswith implemented

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ We're moving functions over to C++! We've done the following so far:
 - [x] `pystr_rstrip`
 - [ ] `pystr_split`
 - [ ] `pystr_splitlines`
-- [ ] `pystr_startswith`
+- [x] `pystr_startswith`
 - [ ] `pystr_strip`
 - [ ] `pystr_swapcase`
 - [ ] `pystr_title`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ We're moving functions over to C++! We've done the following so far:
 - [x] `pystr_center`
 - [x] `pystr_count`
 - [x] `pystr_endswith`
-- [ ] `pystr_find`
+- [x] `pystr_find`
 - [ ] `pystr_format`
 - [ ] `pystr_index`
 - [x] `pystr_isalnum`
@@ -16,7 +16,7 @@ We're moving functions over to C++! We've done the following so far:
 - [ ] `pystr_isspace`
 - [ ] `pystr_istitle`
 - [x] `pystr_isupper`
-- [ ] `pystr_join`
+- [x] `pystr_join`
 - [ ] `pystr_ljust`
 - [ ] `pystr_lower`
 - [x] `pystr_lstrip`
@@ -37,6 +37,6 @@ We're moving functions over to C++! We've done the following so far:
 - [ ] `pystr_title`
 - [ ] `pystr_translate`
 - [ ] `pystr_upper`
-- [ ] `pystr_zfill`
+- [x] `pystr_zfill`
 
 To contribute, pick one of the functions that hasn't been ported to C++ yet. Look at the already-completed functions as examples on how to export a function from C++ to R. Run `make test` to make sure your changes pass all the tests.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PKG_CXXFLAGS=-std=c++11
+PKG_CXXFLAGS=-std=c++0x
 
 test:
 	Rscript -e 'library(methods);library(testthat);devtools::test();'

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+PKG_CXXFLAGS=-std=c++11
+
 test:
 	Rscript -e 'library(methods);library(testthat);devtools::test();'
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -45,3 +45,7 @@ pystr_rstrip_ <- function(strs, chars) {
     .Call('pystr_pystr_rstrip_', PACKAGE = 'pystr', strs, chars)
 }
 
+pystr_startswith_ <- function(inputs, prefixes, start, end) {
+    .Call('pystr_pystr_startswith_', PACKAGE = 'pystr', inputs, prefixes, start, end)
+}
+

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -37,6 +37,10 @@ pystr_isupper_ <- function(strs) {
     .Call('pystr_pystr_isupper_', PACKAGE = 'pystr', strs)
 }
 
+pystr_join_ <- function(input, separator) {
+    .Call('pystr_pystr_join_', PACKAGE = 'pystr', input, separator)
+}
+
 pystr_lstrip_ <- function(strs, chars) {
     .Call('pystr_pystr_lstrip_', PACKAGE = 'pystr', strs, chars)
 }
@@ -47,5 +51,9 @@ pystr_rstrip_ <- function(strs, chars) {
 
 pystr_startswith_ <- function(inputs, prefixes, start, end) {
     .Call('pystr_pystr_startswith_', PACKAGE = 'pystr', inputs, prefixes, start, end)
+}
+
+pystr_zfill_ <- function(inputs, width) {
+    .Call('pystr_pystr_zfill_', PACKAGE = 'pystr', inputs, width)
 }
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -17,6 +17,10 @@ pystr_endswith_ <- function(inputs, suffixes, start, end) {
     .Call('pystr_pystr_endswith_', PACKAGE = 'pystr', inputs, suffixes, start, end)
 }
 
+pystr_find_ <- function(inputs, subs, starts, ends) {
+    .Call('pystr_pystr_find_', PACKAGE = 'pystr', inputs, subs, starts, ends)
+}
+
 pystr_isalnum_ <- function(strs) {
     .Call('pystr_pystr_isalnum_', PACKAGE = 'pystr', strs)
 }

--- a/R/pystr_find.R
+++ b/R/pystr_find.R
@@ -21,21 +21,5 @@
 #'
 #' @export
 pystr_find <- function(str, sub, start=1, end=nchar(str)) {
-  return(mapply(pystr_find_, str, sub, start, end, USE.NAMES=FALSE))
-}
-
-pystr_find_ <- function(str, sub, start, end) {
-  string_to_check = substr(str, start, end)
-
-  for(i in 1:nchar(string_to_check)) {
-    start_check = i
-    end_check = i + nchar(sub) - 1
-    letters_to_check = substr(string_to_check, start_check, end_check)
-
-    if(letters_to_check == sub) {
-      return(start_check + start - 1)
-    }
-  }
-
-  return(-1)
+  return(pystr_find_(str, sub, start, end))
 }

--- a/R/pystr_join.R
+++ b/R/pystr_join.R
@@ -20,16 +20,7 @@
 #' @export
 pystr_join <- function(iterable, sep="") {
   if (is.list(iterable)) {
-    if (length(iterable) > 0) {
-      vals = list()
-
-      for (i in 1:length(iterable)) {
-        vals[[i]] = paste(iterable[[i]], collapse=sep)
-      }
-
-      return(vals)
-    }
-    return(list())
+    return(pystr_join_(unlist(iterable), sep))
   }
-  return(paste(iterable, collapse=sep))
+  return(pystr_join_(iterable,  sep))
 }

--- a/R/pystr_startswith.R
+++ b/R/pystr_startswith.R
@@ -25,13 +25,5 @@
 #'
 #' @export
 pystr_startswith <- function(str, prefix, start=1, end=nchar(str)) {
-  return(mapply(pystr_startswith_, str, prefix, start, end, USE.NAMES=FALSE))
-}
-
-pystr_startswith_ <- function(str, prefix, start, end) {
-  string_to_check = substr(str, start, end)
-  start_check = 1
-  end_check = nchar(prefix)
-  letters_to_check = substr(string_to_check, start_check, end_check)
-  return(letters_to_check == prefix)
+  return(pystr_startswith_(str, prefix, start, end))
 }

--- a/R/pystr_zfill.R
+++ b/R/pystr_zfill.R
@@ -21,23 +21,5 @@
 #'
 #' @export
 pystr_zfill <- function(str, width) {
-  return(vapply(str, function(x) pystr_zfill_(x, width), character(1), USE.NAMES = FALSE))
-}
-
-pystr_zfill_ <- function(str, width) {
-  if(width <= nchar(str)) {
-    return(str)
-  }
-
-  filled = str
-  first_char = substr(filled, 1, 1)
-
-  if(first_char %in% c("-", "+")) {
-    filled = substr(filled, 2, nchar(filled))
-  } else {
-    first_char = ""
-  }
-
-  zeros = pystr_join(rep(0, width - nchar(str)), "")
-  return(pystr_join(c(first_char, zeros, filled), ""))
+  return(pystr_zfill_(str, width))
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -57,6 +57,20 @@ BEGIN_RCPP
     return __result;
 END_RCPP
 }
+// pystr_find_
+IntegerVector pystr_find_(CharacterVector inputs, CharacterVector subs, IntegerVector starts, IntegerVector ends);
+RcppExport SEXP pystr_pystr_find_(SEXP inputsSEXP, SEXP subsSEXP, SEXP startsSEXP, SEXP endsSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< CharacterVector >::type inputs(inputsSEXP);
+    Rcpp::traits::input_parameter< CharacterVector >::type subs(subsSEXP);
+    Rcpp::traits::input_parameter< IntegerVector >::type starts(startsSEXP);
+    Rcpp::traits::input_parameter< IntegerVector >::type ends(endsSEXP);
+    __result = Rcpp::wrap(pystr_find_(inputs, subs, starts, ends));
+    return __result;
+END_RCPP
+}
 // pystr_isalnum_
 LogicalVector pystr_isalnum_(CharacterVector strs);
 RcppExport SEXP pystr_pystr_isalnum_(SEXP strsSEXP) {

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -136,3 +136,17 @@ BEGIN_RCPP
     return __result;
 END_RCPP
 }
+// pystr_startswith_
+LogicalVector pystr_startswith_(CharacterVector inputs, CharacterVector prefixes, NumericVector start, NumericVector end);
+RcppExport SEXP pystr_pystr_startswith_(SEXP inputsSEXP, SEXP prefixesSEXP, SEXP startSEXP, SEXP endSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< CharacterVector >::type inputs(inputsSEXP);
+    Rcpp::traits::input_parameter< CharacterVector >::type prefixes(prefixesSEXP);
+    Rcpp::traits::input_parameter< NumericVector >::type start(startSEXP);
+    Rcpp::traits::input_parameter< NumericVector >::type end(endSEXP);
+    __result = Rcpp::wrap(pystr_startswith_(inputs, prefixes, start, end));
+    return __result;
+END_RCPP
+}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -112,6 +112,18 @@ BEGIN_RCPP
     return __result;
 END_RCPP
 }
+// pystr_join_
+std::string pystr_join_(CharacterVector input, std::string separator);
+RcppExport SEXP pystr_pystr_join_(SEXP inputSEXP, SEXP separatorSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< CharacterVector >::type input(inputSEXP);
+    Rcpp::traits::input_parameter< std::string >::type separator(separatorSEXP);
+    __result = Rcpp::wrap(pystr_join_(input, separator));
+    return __result;
+END_RCPP
+}
 // pystr_lstrip_
 CharacterVector pystr_lstrip_(CharacterVector strs, std::string chars);
 RcppExport SEXP pystr_pystr_lstrip_(SEXP strsSEXP, SEXP charsSEXP) {
@@ -147,6 +159,18 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< NumericVector >::type start(startSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type end(endSEXP);
     __result = Rcpp::wrap(pystr_startswith_(inputs, prefixes, start, end));
+    return __result;
+END_RCPP
+}
+// pystr_zfill_
+CharacterVector pystr_zfill_(CharacterVector inputs, int width);
+RcppExport SEXP pystr_pystr_zfill_(SEXP inputsSEXP, SEXP widthSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< CharacterVector >::type inputs(inputsSEXP);
+    Rcpp::traits::input_parameter< int >::type width(widthSEXP);
+    __result = Rcpp::wrap(pystr_zfill_(inputs, width));
     return __result;
 END_RCPP
 }

--- a/src/index_util.cpp
+++ b/src/index_util.cpp
@@ -1,0 +1,7 @@
+#include <Rcpp.h>
+#include "index_util.h"
+
+int idx(int i, int len) {
+  int j = floor(i / len);
+  return i - (len * j);
+}

--- a/src/index_util.h
+++ b/src/index_util.h
@@ -1,0 +1,8 @@
+#ifndef INDEX_UTIL_H
+#define INDEX_UTIL_H
+
+// This is used to recycle inputs a la mapply.
+// We'll have to use this across the other functions to be consistent.
+int idx(int i, int len);
+
+#endif

--- a/src/pystr_endswith.cpp
+++ b/src/pystr_endswith.cpp
@@ -1,13 +1,9 @@
 #include <Rcpp.h>
-#include <codecvt>
+
+#include "index_util.h"
+#include "string_util.h"
 
 using namespace Rcpp;
-
-std::wstring utf8_str(std::string s) {
-  std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> cv;
-  std::wstring w = cv.from_bytes(s);
-  return w;
-}
 
 bool str_endswith(std::string input, std::string suffix, int start, int end) {
   start--;
@@ -25,17 +21,10 @@ bool str_endswith(std::string input, std::string suffix, int start, int end) {
     return false;
   }
 
-  int len = end - start + 1 < suffix_length ? end - start + 1 : suffix_length;
+  int len = calculate_length(start, end, suffix_length);
 
   std::wstring sub_input = input_w.substr(end - len + 1, len);
   return sub_input == suffix_w;
-}
-
-// This is used to recycle inputs a la mapply.
-// We'll have to use this across the other functions to be consistent.
-int idx(int i, int len) {
-  int j = floor(i / len);
-  return i - (len * j);
 }
 
 // [[Rcpp::export]]

--- a/src/pystr_find.cpp
+++ b/src/pystr_find.cpp
@@ -1,0 +1,45 @@
+#include <Rcpp.h>
+
+#include "index_util.h"
+#include "string_util.h"
+
+using namespace Rcpp;
+
+int str_find(std::string input, std::string sub, int start, int end) {
+  std::wstring input_w = utf8_str(input);
+  std::wstring sub_w = utf8_str(sub);
+  int input_length = input_w.length();
+  int sub_length = sub_w.length();
+  start = start < 1 ? 1 : start;
+  end = end > input_length ? input_length : end;
+
+  if (sub_length == 0) {
+    return 1;
+  }
+  if (input_length < sub_length || start > input_length || end < 1 || start > end) {
+    return -1;
+  }
+
+  std::wstring input_section = input_w.substr(0, end);
+  int result = input_section.find(sub_w, start - 1);
+  return result == -1 ? result : result + 1;
+}
+
+// [[Rcpp::export]]
+IntegerVector pystr_find_(CharacterVector inputs, CharacterVector subs, IntegerVector starts, IntegerVector ends) {
+  int inputs_size = inputs.size();
+  IntegerVector output(inputs_size);
+  int subs_size = subs.size();
+  int starts_size = starts.size();
+  int ends_size = ends.size();
+
+  for (int i = 0; i < inputs_size; i++) {
+    std::string input = Rcpp::as<std::string>(inputs[i]);
+    std::string sub = Rcpp::as<std::string>(subs[idx(i, subs_size)]);
+    int start = starts[idx(i, starts_size)];
+    int end = ends[idx(i, ends_size)];
+    output[i] = str_find(input, sub, start, end);
+  }
+
+  return output;
+}

--- a/src/pystr_join.cpp
+++ b/src/pystr_join.cpp
@@ -1,0 +1,29 @@
+#include <Rcpp.h>
+
+using namespace Rcpp;
+
+// [[Rcpp::export]]
+std::string pystr_join_(CharacterVector input, std::string separator) {
+  int input_size = input.size();
+  if (input_size == 0) {
+    return std::string("");
+  }
+  std::string input_strings[input_size];
+  int total_size = 0;
+  int sep_length = separator.length();
+
+  for (int i = 0; i < input_size; i++) {
+    input_strings[i] = Rcpp::as<std::string>(input[i]);
+    total_size += input_strings[i].length();
+  }
+  total_size += (sep_length * (input_size - 1));
+  std::string output;
+  output.reserve(total_size);
+  for (int i = 0; i < input_size; i++) {
+    output.append(input_strings[i]);
+    if (i + 1 < input_size) {
+      output.append(separator);
+    }
+  }
+  return output;
+}

--- a/src/pystr_startswith.cpp
+++ b/src/pystr_startswith.cpp
@@ -1,0 +1,54 @@
+#include <Rcpp.h>
+
+#include "index_util.h"
+#include "string_util.h"
+
+using namespace Rcpp;
+
+bool str_startswith(std::string input, std::string prefix, int start, int end) {
+  start = start < 1 ? 0 : start - 1;
+  end--;
+
+  std::wstring input_w = utf8_str(input);
+  std::wstring prefix_w = utf8_str(prefix);
+  int input_length = input_w.length();
+  int prefix_length = prefix_w.length();
+
+  if (prefix_length == 0) {
+    return true;
+  }
+  if (input_length < prefix_length || start > input_length || end < 0 || start > end) {
+    return false;
+  }
+
+  int len = calculate_length(start, end, prefix_length);
+  std::wstring sub_input = input_w.substr(start, len);
+  return sub_input == prefix_w;
+}
+
+// [[Rcpp::export]]
+LogicalVector pystr_startswith_(CharacterVector inputs,
+                                CharacterVector prefixes,
+                                NumericVector start,
+                                NumericVector end) {
+  int inputs_size = inputs.size();
+  LogicalVector output(inputs_size);
+  int prefixes_size = prefixes.size();
+  int start_size = start.size();
+  int end_size = end.size();
+
+  for (int i = 0; i < inputs_size; i++) {
+    std::string input = Rcpp::as<std::string>(inputs[i]);
+    std::string prefix = Rcpp::as<std::string>(prefixes[idx(i, prefixes_size)]);
+    int s = start[idx(i, start_size)];
+    int e = end[idx(i, end_size)];
+
+    if (inputs[i] == NA_STRING) {
+      output[i] = NA_LOGICAL;
+    } else {
+      output[i] = str_startswith(input, prefix, s, e);
+    }
+  }
+
+  return output;
+}

--- a/src/pystr_zfill.cpp
+++ b/src/pystr_zfill.cpp
@@ -11,6 +11,26 @@ std::string generate_zeroes(int length) {
   return result;
 }
 
+std::string str_fill(std::string input, int width) {
+  int zeroes_length = width - input.length();
+  if (zeroes_length > 0) {
+    std::string filledInput;
+    filledInput.reserve(width);
+    std::string zeroes = generate_zeroes(zeroes_length);
+    if (input.at(0) == '+' || input.at(0) == '-') {
+      filledInput.append(input.substr(0, 1));
+      filledInput.append(zeroes);
+      filledInput.append(input.substr(1));
+    } else {
+      filledInput.append(zeroes);
+      filledInput.append(input);
+    }
+    return filledInput;
+  } else {
+    return input;
+  }
+}
+
 // [[Rcpp::export]]
 CharacterVector pystr_zfill_(CharacterVector inputs, int width) {
   int inputs_size = inputs.size();
@@ -18,23 +38,7 @@ CharacterVector pystr_zfill_(CharacterVector inputs, int width) {
 
   for (int i = 0; i < inputs_size; i++) {
     std::string input = Rcpp::as<std::string>(inputs[i]);
-    int zeroes_length = width - input.length();
-    if (zeroes_length > 0) {
-      std::string filledInput;
-      filledInput.reserve(width);
-      std::string zeroes = generate_zeroes(zeroes_length);
-      if (input.at(0) == '+' || input.at(0) == '-') {
-        filledInput.append(input.substr(0, 1));
-        filledInput.append(zeroes);
-        filledInput.append(input.substr(1));
-      } else {
-        filledInput.append(zeroes);
-        filledInput.append(input);
-      }
-      output[i] = filledInput;
-    } else {
-      output[i] = input;
-    }
+    output[i] = str_fill(input, width);
   }
 
   return output;

--- a/src/pystr_zfill.cpp
+++ b/src/pystr_zfill.cpp
@@ -1,0 +1,41 @@
+#include <Rcpp.h>
+
+using namespace Rcpp;
+
+std::string generate_zeroes(int length) {
+  std::string result;
+  result.reserve(length);
+  for (int i = 0; i < length; i++) {
+    result.append("0");
+  }
+  return result;
+}
+
+// [[Rcpp::export]]
+CharacterVector pystr_zfill_(CharacterVector inputs, int width) {
+  int inputs_size = inputs.size();
+  CharacterVector output(inputs_size);
+
+  for (int i = 0; i < inputs_size; i++) {
+    std::string input = Rcpp::as<std::string>(inputs[i]);
+    int zeroes_length = width - input.length();
+    if (zeroes_length > 0) {
+      std::string filledInput;
+      filledInput.reserve(width);
+      std::string zeroes = generate_zeroes(zeroes_length);
+      if (input.at(0) == '+' || input.at(0) == '-') {
+        filledInput.append(input.substr(0, 1));
+        filledInput.append(zeroes);
+        filledInput.append(input.substr(1));
+      } else {
+        filledInput.append(zeroes);
+        filledInput.append(input);
+      }
+      output[i] = filledInput;
+    } else {
+      output[i] = input;
+    }
+  }
+
+  return output;
+}

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -1,0 +1,12 @@
+#include <Rcpp.h>
+#include <codecvt>
+#include "string_util.h"
+
+std::wstring utf8_str(std::string s) {
+  std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> cv;
+  return cv.from_bytes(s);
+}
+
+int calculate_length(int start, int end, int particle_length) {
+  return end - start + 1 < particle_length ? end - start + 1 : particle_length;
+}

--- a/src/string_util.h
+++ b/src/string_util.h
@@ -1,0 +1,9 @@
+#ifndef STRING_UTIL_H
+#define STRING_UTIL_H
+
+#include <codecvt>
+
+std::wstring utf8_str(std::string s);
+int calculate_length(int start, int end, int particle_length);
+
+#endif

--- a/tests/testthat/test-pystr_join.R
+++ b/tests/testthat/test-pystr_join.R
@@ -12,3 +12,7 @@ test_that("it joins strings", {
 test_that("it joins on empty strings by default", {
   expect_equal(pystr_join(c("A", "B", "C")), "ABC")
 })
+
+test_that("it joins unicode strings passing empty separators", {
+  expect_equal(pystr_join(c("D", "E", "F", "Ç"), sep=""), "DEFÇ")
+})

--- a/tests/testthat/test-pystr_lower.R
+++ b/tests/testthat/test-pystr_lower.R
@@ -8,3 +8,7 @@ test_that("it converts to lowercase", {
 test_that("it works with a character vector", {
   expect_equal(pystr_lower(c("HELLO!", "hellO")), c("hello!", "hello"))
 })
+
+test_that("it works with unicode characters", {
+  expect_equal(pystr_lower(c("ÇATALHÖYÜK", "MÜLLER")), c("çatalhöyük", "müller"))
+})

--- a/tests/testthat/test-pystr_startswith.R
+++ b/tests/testthat/test-pystr_startswith.R
@@ -28,3 +28,22 @@ test_that("it works with a character vector", {
 test_that("it works with multiple character vectors", {
   expect_equal(pystr_startswith(c("http://", "https://"), c("http://", "https://")), c(TRUE, TRUE))
 })
+
+test_that("it recycles arguments", {
+ input = c("soccer.jpg", "tennis.jpg", "soccer.png", "tennis.png")
+ output = rep(TRUE, 4)
+
+ expect_equal(pystr_startswith(input, c("soccer", "tennis")), output)
+})
+
+test_that("it works with an unicode string suffix that's present", {
+  str <- "abçläss"
+  prefix <- "ab"
+  expect_true(pystr_startswith(str, prefix))
+})
+
+test_that("it works with a unicode suffix", {
+  str <- "baçäök"
+  prefix <- "baçäö"
+  expect_true(pystr_startswith(str, prefix))
+})

--- a/tests/testthat/test-pystr_upper.R
+++ b/tests/testthat/test-pystr_upper.R
@@ -8,3 +8,7 @@ test_that("it converts to lowercase", {
 test_that("it works with a character vector", {
   expect_equal(pystr_upper(c("Hello", "World")), c("HELLO", "WORLD"))
 })
+
+test_that("it works with unicode characters", {
+  expect_equal(pystr_upper(c("çatalhöyük", "Müller")), c("ÇATALHÖYÜK", "MÜLLER"))
+})


### PR DESCRIPTION
I added the PKG_CXXFLAGS=-std=c++11 in Makefile since it is not default in GCC 5.3. GCC 6 uses c++14 as default.

I implemented pystr_startswith using the same idea used in pystr_endswith.
